### PR TITLE
feat(mobile-nav): promote Tournaments + label More pill (#10)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -359,7 +359,6 @@ a {
 .mobile-nav__bar {
   display: flex;
   align-items: center;
-  gap: 10px;
   width: 100%;
   max-width: 100%;
   padding: 0 4px;
@@ -369,8 +368,8 @@ a {
   flex: 1;
   min-width: 0;
   align-items: stretch;
-  gap: 8px;
-  padding: 6px 6px;
+  gap: 2px;
+  padding: 6px 4px;
   border-radius: var(--radius-full);
   background: rgba(0, 0, 0, 0.35);
   backdrop-filter: saturate(var(--glass-dark-saturate)) blur(var(--glass-dark-blur));
@@ -387,13 +386,13 @@ a {
   flex: 1;
   min-width: 0;
   min-height: 48px;
-  padding: 8px 4px;
+  padding: 8px 2px;
   border-radius: calc(var(--radius-full) - 4px);
   border: none;
   background: transparent;
   font-family: inherit;
   font-weight: 600;
-  font-size: 0.65rem;
+  font-size: 0.72rem;
   line-height: 1.1;
   text-decoration: none;
   text-align: center;
@@ -436,43 +435,6 @@ a {
 }
 .mobile-nav__item--active .mobile-nav__item-icon {
   color: var(--fg);
-}
-.mobile-nav__more {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Match pill height: 6px padding + 48px item min-height + 6px padding = 60px */
-  width: 60px;
-  height: 60px;
-  min-width: 60px;
-  min-height: 60px;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.05);
-  backdrop-filter: saturate(var(--glass-dark-saturate)) blur(var(--glass-dark-blur));
-  -webkit-backdrop-filter: saturate(var(--glass-dark-saturate)) blur(var(--glass-dark-blur));
-  border: 1px solid var(--glass-dark-border);
-  box-shadow: var(--glass-dark-shadow);
-  color: var(--fg);
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  transition:
-    background var(--transition),
-    transform var(--transition);
-}
-.mobile-nav__more:hover {
-  background: var(--glass-dark-active-bg);
-  transform: scale(1.02);
-}
-.mobile-nav__more-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.mobile-nav__more-icon svg {
-  width: 24px;
-  height: 24px;
 }
 .mobile-nav__backdrop {
   position: fixed;

--- a/apps/web/src/lib/MobileNavBar.svelte
+++ b/apps/web/src/lib/MobileNavBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import IconTrophy from '$lib/icons/IconTrophy.svelte';
+  import IconCrownOutline from '$lib/icons/IconCrownOutline.svelte';
   import IconBarChart from '$lib/icons/IconBarChart.svelte';
   import IconSparkle from '$lib/icons/IconSparkle.svelte';
   import IconMore from '$lib/icons/IconMore.svelte';
@@ -17,6 +18,7 @@
       $page.url.pathname !== '/matches/new' &&
       $page.url.pathname !== '/matches/quick'
   );
+  const isTournaments = $derived($page.url.pathname.startsWith('/tournaments'));
   const isStats = $derived($page.url.pathname === '/stats');
   const isMyStatistics = $derived($page.url.pathname === '/me/statistics');
   const isStatsSection = $derived(isStats || isMyStatistics);
@@ -48,28 +50,40 @@
         <span class="mobile-nav__item-label">Matches</span>
       </a>
       <a
+        href="/tournaments"
+        class="mobile-nav__item"
+        class:mobile-nav__item--active={isTournaments}
+        aria-current={isTournaments ? 'page' : undefined}
+      >
+        <span class="mobile-nav__item-icon" aria-hidden="true">
+          <IconCrownOutline size={24} />
+        </span>
+        <span class="mobile-nav__item-label">Tournaments</span>
+      </a>
+      <a
         href="/stats"
         class="mobile-nav__item"
         class:mobile-nav__item--active={isStatsSection}
-        aria-current={isStats ? 'page' : undefined}
+        aria-current={isStatsSection ? 'page' : undefined}
       >
         <span class="mobile-nav__item-icon" aria-hidden="true">
           <IconBarChart size={24} />
         </span>
         <span class="mobile-nav__item-label">Statistics</span>
       </a>
+      <button
+        type="button"
+        class="mobile-nav__item mobile-nav__item--more"
+        aria-label={menuOpen ? 'Close menu' : 'More menu'}
+        aria-expanded={menuOpen}
+        aria-controls="mobile-nav-drawer"
+        onclick={onMoreClick}
+      >
+        <span class="mobile-nav__item-icon" aria-hidden="true">
+          <IconMore size={24} />
+        </span>
+        <span class="mobile-nav__item-label">More</span>
+      </button>
     </nav>
-    <button
-      type="button"
-      class="mobile-nav__more"
-      aria-label={menuOpen ? 'Close menu' : 'More menu'}
-      aria-expanded={menuOpen}
-      aria-controls="mobile-nav-drawer"
-      onclick={onMoreClick}
-    >
-      <span class="mobile-nav__more-icon" aria-hidden="true">
-        <IconMore size={24} />
-      </span>
-    </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Promotes **Tournaments** to the mobile bottom nav so it is reachable in one tap. New order: Dashboard, Matches, Tournaments, Statistics, More (uses `IconCrownOutline`, mirroring the drawer entry).
- Converts the circular **More** pill into a labelled tab item that lives inside the same pill, matching the visual style of the other tabs while keeping the existing `aria-label`/`aria-expanded`/`aria-controls` behaviour.
- Bumps `.mobile-nav__item-label` from `0.65rem` to `0.72rem` and tightens pill `gap`/`padding` so all five items fit cleanly on common phone widths without wrapping.
- Fixes `aria-current` on the **Statistics** tab to use `isStatsSection` (which already drives the active class) so screen-reader state matches the visual state on `/me/statistics`.
- Drops the now-unused `.mobile-nav__more*` CSS rules.

## Test plan
- [x] `npx eslint apps/web/src/lib/MobileNavBar.svelte apps/web/src/lib/MobileNavDrawer.svelte` — clean.
- [x] `npm run build:web` — succeeds.
- [ ] Manual: load on a 360–390px viewport, verify all 5 tabs render without wrapping, "Tournaments" route shows the Tournaments tab as active, `/me/statistics` shows Statistics tab as active *and* announces `aria-current=page`, More opens/closes the drawer with correct `aria-expanded`.

Closes #10