### PR TITLE
feat(a11y): focus trap, scroll lock, slide animation, drop duplicate close (#12)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -613,9 +613,17 @@ a {
 @keyframes topbar-drawer-in-fullscreen {
   from {
     opacity: 0;
+    transform: translateY(16px);
   }
   to {
     opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mobile-nav__drawer,
+  .topbar__drawer {
+    animation: none;
   }
 }
 @media (min-width: 640px) {

--- a/apps/web/src/lib/DeckPickerModal.svelte
+++ b/apps/web/src/lib/DeckPickerModal.svelte
@@ -4,6 +4,7 @@
   import { DECK_COLOR_OPTIONS } from '$lib/matches';
   import InkIcons from '$lib/InkIcons.svelte';
   import Pagination from '$lib/Pagination.svelte';
+  import { focusTrap, scrollLock } from '$lib/a11y';
 
   /** Move the modal root to document.body so it covers the full viewport. */
   function portal(node: HTMLElement) {
@@ -161,7 +162,7 @@
       aria-label="Close"
       onclick={onClose}
     ></button>
-    <div class="deck-picker-modal__card card">
+    <div class="deck-picker-modal__card card" use:focusTrap use:scrollLock>
       <h2 id="deck-picker-title" class="deck-picker-modal__title">{title}</h2>
       {#if forLabel}
         <p class="deck-picker-modal__for muted">Selecting deck for <strong>{forLabel}</strong></p>

--- a/apps/web/src/lib/GameAnalysePopup.svelte
+++ b/apps/web/src/lib/GameAnalysePopup.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { focusTrap, scrollLock } from '$lib/a11y';
+
   type Props = {
     /** When true, the popup is shown. */
     open: boolean;
@@ -44,7 +46,11 @@
       aria-label="Close"
       onclick={handleClose}
     ></button>
-    <div class="delete-game-modal__card card game-analyse-modal__card">
+    <div
+      class="delete-game-modal__card card game-analyse-modal__card"
+      use:focusTrap
+      use:scrollLock
+    >
       <h2 id="game-analyse-title" class="delete-game-modal__title">
         {title}
       </h2>

--- a/apps/web/src/lib/MobileNavDrawer.svelte
+++ b/apps/web/src/lib/MobileNavDrawer.svelte
@@ -9,6 +9,7 @@
   import IconUser from '$lib/icons/IconUser.svelte';
   import IconLogOut from '$lib/icons/IconLogOut.svelte';
   import IconClose from '$lib/icons/IconClose.svelte';
+  import { focusTrap, scrollLock } from '$lib/a11y';
 
   interface Props {
     open: boolean;
@@ -46,7 +47,13 @@
 
 {#if open}
   <div class="mobile-nav__backdrop" role="presentation" onclick={closeMenu}></div>
-  <nav id="mobile-nav-drawer" class="mobile-nav__drawer" aria-label="More menu">
+  <nav
+    id="mobile-nav-drawer"
+    class="mobile-nav__drawer"
+    aria-label="More menu"
+    use:focusTrap
+    use:scrollLock
+  >
     <button
       type="button"
       class="mobile-nav__drawer-close"
@@ -160,18 +167,6 @@
         <IconLogOut size={24} />
       </span>
       Logout
-    </button>
-    <div class="mobile-nav__drawer-divider" role="separator" aria-hidden="true"></div>
-    <button
-      type="button"
-      class="mobile-nav__drawer-link mobile-nav__drawer-link--button mobile-nav__drawer-link--close"
-      aria-label="Close menu"
-      onclick={closeMenu}
-    >
-      <span class="mobile-nav__drawer-link-icon" aria-hidden="true">
-        <IconClose size={24} />
-      </span>
-      Close
     </button>
   </nav>
 {/if}

--- a/apps/web/src/lib/PlayerPickerModal.svelte
+++ b/apps/web/src/lib/PlayerPickerModal.svelte
@@ -2,6 +2,7 @@
   import { config } from '$lib/config';
   import { getAuthToken } from '$lib/auth';
   import Pagination from '$lib/Pagination.svelte';
+  import { focusTrap, scrollLock } from '$lib/a11y';
 
   /** Move the modal root to document.body so it covers the full viewport. */
   function portal(node: HTMLElement) {
@@ -140,7 +141,7 @@
       aria-label="Close"
       onclick={onClose}
     ></button>
-    <div class="player-picker-modal__card card">
+    <div class="player-picker-modal__card card" use:focusTrap use:scrollLock>
       <h2 id="player-picker-title" class="player-picker-modal__title">{title}</h2>
       {#if forLabel}
         <p class="player-picker-modal__for muted">Selecting player for <strong>{forLabel}</strong></p>

--- a/apps/web/src/lib/TournamentPickerModal.svelte
+++ b/apps/web/src/lib/TournamentPickerModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { focusTrap, scrollLock } from '$lib/a11y';
+
   /** Move the modal root to document.body so it covers the full viewport. */
   function portal(node: HTMLElement) {
     document.body.appendChild(node);
@@ -74,7 +76,7 @@
       aria-label="Close"
       onclick={onClose}
     ></button>
-    <div class="tournament-picker-modal__card card">
+    <div class="tournament-picker-modal__card card" use:focusTrap use:scrollLock>
       <h2 id="tournament-picker-title" class="tournament-picker-modal__title">{title}</h2>
       <p class="tournament-picker-modal__hint muted">Optional — link this match to a tournament event.</p>
 

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -1,0 +1,118 @@
+/**
+ * Accessibility helpers for modal/dialog components.
+ *
+ * - `focusTrap` keeps Tab/Shift+Tab inside the dialog, focuses an initial
+ *   element on mount, and restores focus to the previously focused element
+ *   on destroy.
+ * - `scrollLock` prevents the page underneath the dialog from scrolling.
+ *   Reference-counted so multiple stacked dialogs unlock correctly.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
+
+function getFocusable(node: HTMLElement): HTMLElement[] {
+  const nodes = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  return Array.from(nodes).filter(
+    (el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true'
+  );
+}
+
+export interface FocusTrapOptions {
+  /** Element to focus on mount. Defaults to the first focusable child. */
+  initialFocus?: HTMLElement | null;
+}
+
+/**
+ * Svelte action: trap Tab focus inside `node` while it is mounted.
+ * Restores focus to the previously focused element on destroy.
+ */
+export function focusTrap(node: HTMLElement, opts: FocusTrapOptions = {}) {
+  const previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  const focusInitial = () => {
+    const target =
+      opts.initialFocus && node.contains(opts.initialFocus)
+        ? opts.initialFocus
+        : getFocusable(node)[0] ?? node;
+    if (!target.hasAttribute('tabindex') && target === node) {
+      node.setAttribute('tabindex', '-1');
+    }
+    target.focus({ preventScroll: true });
+  };
+
+  // Defer to next microtask so the node and its children are fully mounted.
+  Promise.resolve().then(focusInitial);
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Tab') return;
+    const focusable = getFocusable(node);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      node.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    const goingBackward = event.shiftKey;
+    if (!goingBackward && active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    } else if (goingBackward && (active === first || !node.contains(active))) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    }
+  };
+
+  node.addEventListener('keydown', onKeyDown);
+
+  return {
+    destroy() {
+      node.removeEventListener('keydown', onKeyDown);
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    },
+  };
+}
+
+let scrollLockCount = 0;
+let savedBodyOverflow = '';
+
+/**
+ * Svelte action: lock body scroll while `node` is mounted.
+ * Reference-counted so multiple concurrent dialogs unlock correctly.
+ */
+export function scrollLock(node: HTMLElement) {
+  // The node arg is required by the Svelte action signature; the lock is
+  // applied globally to <body>, not to `node` itself.
+  void node;
+  if (scrollLockCount === 0) {
+    savedBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  scrollLockCount += 1;
+
+  return {
+    destroy() {
+      scrollLockCount = Math.max(0, scrollLockCount - 1);
+      if (scrollLockCount === 0) {
+        document.body.style.overflow = savedBodyOverflow;
+        savedBodyOverflow = '';
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `apps/web/src/lib/a11y.ts` with two Svelte actions:
  - `focusTrap` — cycles Tab/Shift+Tab inside a dialog, focuses an initial element on mount, and restores focus to the previously focused element on destroy.
  - `scrollLock` — locks `document.body` overflow while a dialog is mounted, reference-counted so stacked dialogs unlock correctly.
- Applies both actions to the dialog wrapper of `MobileNavDrawer`, `PlayerPickerModal`, `DeckPickerModal`, `TournamentPickerModal`, and `GameAnalysePopup`.
- Replaces the opacity-only `@keyframes topbar-drawer-in-fullscreen` with a slide-up + fade and disables it under `prefers-reduced-motion: reduce`.
- Removes the redundant bottom Close button in `MobileNavDrawer` (the X close in the top-right is kept).

Closes #12

## Test plan
- [ ] Open each dialog and confirm Tab/Shift+Tab stays inside; closing returns focus to the trigger.
- [ ] Open a modal and confirm the page behind no longer scrolls.
- [ ] Open the mobile nav drawer and confirm the new slide-up + fade animation; verify motion is suppressed with `prefers-reduced-motion: reduce`.
- [ ] Confirm only the top-right X close remains in the mobile nav drawer.
- [ ] `npm run build:web` succeeds.


Made with [Cursor](https://cursor.com)