### PR TITLE
refactor(filters): unify filter card pattern and page size across lists (#11)

### DIFF
--- a/apps/api/src/constants/index.ts
+++ b/apps/api/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_PORT = 3001;
+export const DEFAULT_PORT = 3301;
 export const DEFAULT_MONGODB_URI = 'mongodb://localhost:27017/big-ink-lab';
 export const MONGO_READY_STATE_CONNECTED = 1;
 

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -954,6 +954,90 @@ a {
   font-size: 0.9rem;
 }
 
+/* Shared collapsible filter card – used by /matches, /players, /decks (FilterCard.svelte). */
+.filter-card-wrap {
+  margin-top: var(--space-md, 1rem);
+  margin-bottom: var(--space-md, 1rem);
+}
+.filter-card {
+  gap: 0;
+}
+.filter-card__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.75rem;
+  padding: 0.65rem 0.35rem;
+  margin: 0;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+.filter-card__toggle:hover {
+  background: var(--glass-bg-strong, rgba(255, 255, 255, 0.06));
+}
+.filter-card__toggle-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.filter-card__toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+.filter-card__toggle:hover .filter-card__toggle-icon {
+  color: var(--fg);
+}
+.filter-card__toggle-label {
+  flex-shrink: 0;
+}
+.filter-card__toggle-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink, #a855f7) 18%, transparent);
+  color: var(--fg);
+}
+.filter-card__chevron {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+  width: 1.25rem;
+  text-align: center;
+}
+.filter-card__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid color-mix(in srgb, var(--fg, #fafafa) 10%, transparent);
+  margin-top: 0.35rem;
+}
+.filter-card__count {
+  margin: 0;
+  font-size: 0.875rem;
+}
+.filter-card__summary {
+  margin: 0.35rem 0 0;
+  padding: 0 0.35rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
 .game-line {
   position: relative;
   margin: 0;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -924,7 +924,7 @@ a {
   font-size: 0.9rem;
 }
 
-/* Shared collapsible filter card – used by /matches, /players, /decks (FilterCard.svelte). */
+/* Shared collapsible filter card – used by /matches, /players, /decks, /tournaments/[id] (FilterCard.svelte). */
 .filter-card-wrap {
   margin-top: var(--space-md, 1rem);
   margin-bottom: var(--space-md, 1rem);
@@ -1006,6 +1006,23 @@ a {
   padding: 0 0.35rem;
   font-size: 0.875rem;
   line-height: 1.4;
+}
+.filter-card__collapsed-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-top: 0.35rem;
+  padding: 0 0.35rem;
+}
+.filter-card__summary--inline {
+  margin: 0;
+  flex: 1;
+  min-width: min(100%, 12rem);
+}
+.filter-card__clear {
+  flex-shrink: 0;
 }
 
 .game-line {

--- a/apps/web/src/lib/FilterCard.svelte
+++ b/apps/web/src/lib/FilterCard.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import IconFilter from '$lib/icons/IconFilter.svelte';
+
+  interface Props {
+    /** Header label shown next to the filter icon. */
+    title?: string;
+    /** Two-way bindable expanded state. Defaults to collapsed. */
+    expanded?: boolean;
+    /** Small text shown beneath the card while collapsed (e.g. "12 items, guests hidden"). */
+    summary?: string;
+    /** Chips rendered next to the title to surface active filters at a glance. */
+    badges?: string[];
+    /** Filter inputs rendered inside the panel when expanded. */
+    children?: Snippet;
+    /** Stable id used to link the toggle button to the panel for assistive tech. */
+    panelId?: string;
+  }
+
+  let {
+    title = 'Filters',
+    expanded = $bindable(false),
+    summary = '',
+    badges = [],
+    children,
+    panelId = 'filter-card-panel',
+  }: Props = $props();
+
+  function toggle() {
+    expanded = !expanded;
+  }
+</script>
+
+<div class="filter-card-wrap">
+  <div class="card stack filter-card">
+    <button
+      type="button"
+      class="filter-card__toggle"
+      aria-expanded={expanded}
+      aria-controls={panelId}
+      onclick={toggle}
+    >
+      <span class="filter-card__toggle-main">
+        <span class="filter-card__toggle-icon" aria-hidden="true">
+          <IconFilter size={20} />
+        </span>
+        <span class="filter-card__toggle-label">{title}</span>
+        {#each badges as badge (badge)}
+          <span class="filter-card__toggle-badge" aria-hidden="true">{badge}</span>
+        {/each}
+      </span>
+      <span class="filter-card__chevron" aria-hidden="true">{expanded ? '▼' : '▶'}</span>
+    </button>
+    {#if expanded}
+      <div id={panelId} class="filter-card__panel">
+        {@render children?.()}
+        {#if summary}
+          <p class="filter-card__count muted">{summary}</p>
+        {/if}
+      </div>
+    {/if}
+  </div>
+  {#if !expanded && summary}
+    <p class="muted filter-card__summary">{summary}</p>
+  {/if}
+</div>

--- a/apps/web/src/lib/FilterCard.svelte
+++ b/apps/web/src/lib/FilterCard.svelte
@@ -15,6 +15,12 @@
     children?: Snippet;
     /** Stable id used to link the toggle button to the panel for assistive tech. */
     panelId?: string;
+    /** When set, a Clear control is shown next to the collapsed summary so filters can be reset without expanding. */
+    onClear?: () => void;
+    /** Whether {@link onClear} should be enabled. Required when `onClear` is used. */
+    canClear?: boolean;
+    /** Label for the collapsed (and optional) clear control. */
+    clearLabel?: string;
   }
 
   let {
@@ -24,6 +30,9 @@
     badges = [],
     children,
     panelId = 'filter-card-panel',
+    onClear,
+    canClear = false,
+    clearLabel = 'Clear filters',
   }: Props = $props();
 
   function toggle() {
@@ -60,7 +69,21 @@
       </div>
     {/if}
   </div>
-  {#if !expanded && summary}
-    <p class="muted filter-card__summary">{summary}</p>
+  {#if !expanded && (summary || onClear)}
+    <div class="filter-card__collapsed-row">
+      {#if summary}
+        <p class="muted filter-card__summary filter-card__summary--inline">{summary}</p>
+      {/if}
+      {#if onClear}
+        <button
+          type="button"
+          class="btn filter-card__clear"
+          onclick={() => onClear?.()}
+          disabled={!canClear}
+        >
+          {clearLabel}
+        </button>
+      {/if}
+    </div>
   {/if}
 </div>

--- a/apps/web/src/routes/decks/+page.svelte
+++ b/apps/web/src/routes/decks/+page.svelte
@@ -4,6 +4,7 @@
   import type { Deck } from '$lib/decks';
   import { getDeckPlayerName } from '$lib/decks';
   import { DECK_COLOR_OPTIONS } from '$lib/matches';
+  import FilterCard from '$lib/FilterCard.svelte';
   import InkIcons from '$lib/InkIcons.svelte';
   import Pagination from '$lib/Pagination.svelte';
 
@@ -21,7 +22,21 @@
   let totalPages = $state(1);
   let total = $state(0);
 
+  /** Filter panel starts collapsed (shared FilterCard pattern). */
+  let filtersExpanded = $state(false);
+
   const apiUrl = config.apiUrl ?? '/api';
+
+  const filterSummary = $derived(`${total} deck${total === 1 ? '' : 's'}`);
+  const selectedPlayerName = $derived(
+    filterPlayer ? (players.find((p) => p._id === filterPlayer)?.name ?? '') : ''
+  );
+  const filterBadges = $derived<string[]>(
+    [
+      filterColor ? `Color: ${filterColor}` : '',
+      selectedPlayerName ? `Player: ${selectedPlayerName}` : '',
+    ].filter((b) => b.length > 0)
+  );
 
   async function loadDecks() {
     loading = true;
@@ -31,7 +46,7 @@
       if (filterColor.trim()) params.set('color', filterColor.trim());
       if (filterPlayer.trim()) params.set('player', filterPlayer.trim());
       params.set('page', String(currentPage));
-      params.set('limit', '5');
+      params.set('limit', '15');
       const url = `${apiUrl}/decks?${params}`;
       const res = await fetch(url);
       if (!res.ok) {
@@ -116,7 +131,7 @@
     <div class="card" role="alert" aria-live="assertive">
       <p class="alert">{error}</p>
     </div>
-  {:else if decks.length === 0}
+  {:else if decks.length === 0 && !filterColor && !filterPlayer}
     <div class="card stack">
       <h2 class="card__title">No decks yet</h2>
       <p class="card__sub">Create a deck with name and card list.</p>
@@ -134,34 +149,45 @@
       <a href="/decks/new" class="btn btn--primary">New deck</a>
     </div>
 
-    <div class="decks-filters">
-      <label for="filter-color" class="decks-filters__label">Deck color</label>
-      <select
-        id="filter-color"
-        class="input decks-filters__select"
-        bind:value={filterColor}
-        onchange={onFilterChange}
-        aria-label="Filter by deck color"
-      >
-        <option value="">All</option>
-        {#each DECK_COLOR_OPTIONS as color (color)}
-          <option value={color}>{color}</option>
-        {/each}
-      </select>
-      <label for="filter-player" class="decks-filters__label">Player</label>
-      <select
-        id="filter-player"
-        class="input decks-filters__select"
-        bind:value={filterPlayer}
-        onchange={onFilterChange}
-        aria-label="Filter by player"
-      >
-        <option value="">All</option>
-        {#each players as p (p._id)}
-          <option value={p._id}>{p.name}</option>
-        {/each}
-      </select>
-    </div>
+    <FilterCard
+      bind:expanded={filtersExpanded}
+      summary={filterSummary}
+      badges={filterBadges}
+      panelId="decks-filters-panel"
+    >
+      <div class="filters__row">
+        <label class="filters__label" for="filter-color">
+          <span class="muted" style="font-size: 0.85rem;">Deck color</span>
+          <select
+            id="filter-color"
+            class="input filters__select"
+            bind:value={filterColor}
+            onchange={onFilterChange}
+            aria-label="Filter by deck color"
+          >
+            <option value="">All</option>
+            {#each DECK_COLOR_OPTIONS as color (color)}
+              <option value={color}>{color}</option>
+            {/each}
+          </select>
+        </label>
+        <label class="filters__label" for="filter-player">
+          <span class="muted" style="font-size: 0.85rem;">Player</span>
+          <select
+            id="filter-player"
+            class="input filters__select"
+            bind:value={filterPlayer}
+            onchange={onFilterChange}
+            aria-label="Filter by player"
+          >
+            <option value="">All</option>
+            {#each players as p (p._id)}
+              <option value={p._id}>{p.name}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+    </FilterCard>
 
     <div class="stack">
       {#if decks.length === 0 && (filterColor || filterPlayer)}
@@ -202,21 +228,6 @@
 </div>
 
 <style>
-  .decks-filters {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: var(--space-md);
-    margin-bottom: var(--space-lg);
-  }
-  .decks-filters__label {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--muted);
-  }
-  .decks-filters__select {
-    min-width: 10rem;
-  }
   .deckcard__name {
     font-weight: 700;
     font-size: 1.1rem;

--- a/apps/web/src/routes/decks/+page.svelte
+++ b/apps/web/src/routes/decks/+page.svelte
@@ -97,6 +97,14 @@
     currentPage = 1;
   }
 
+  function clearDeckFilters() {
+    filterColor = '';
+    filterPlayer = '';
+    currentPage = 1;
+  }
+
+  const canClearDeckFilters = $derived(!!(filterColor.trim() || filterPlayer.trim()));
+
   function handlePageChange(page: number) {
     currentPage = page;
   }
@@ -154,6 +162,8 @@
       summary={filterSummary}
       badges={filterBadges}
       panelId="decks-filters-panel"
+      onClear={clearDeckFilters}
+      canClear={canClearDeckFilters}
     >
       <div class="filters__row">
         <label class="filters__label" for="filter-color">

--- a/apps/web/src/routes/matches/+page.svelte
+++ b/apps/web/src/routes/matches/+page.svelte
@@ -14,6 +14,7 @@
   import InkIcons from '$lib/InkIcons.svelte';
   import IconCrown from '$lib/icons/IconCrown.svelte';
   import IconUpload from '$lib/icons/IconUpload.svelte';
+  import FilterCard from '$lib/FilterCard.svelte';
   import Pagination from '$lib/Pagination.svelte';
   import PlayerPickerModal from '$lib/PlayerPickerModal.svelte';
 
@@ -23,7 +24,7 @@
   let loading = $state(true);
   let error = $state('');
 
-  const PAGE_SIZE = 10;
+  const PAGE_SIZE = 15;
 
   let filterStage = $state<string>('');
   /** When set (from URL `?tournamentId=`), filters matches linked to that tournament entity. */
@@ -37,6 +38,9 @@
   let totalPages = $state(1);
   let total = $state(0);
 
+  /** Filter panel starts collapsed (shared FilterCard pattern). */
+  let filtersExpanded = $state(false);
+
   /** Logged-in user’s player (for showing Duels import when linked). */
   let myPlayerId = $state<string | null>(null);
   let duelsImportInput = $state<HTMLInputElement | null>(null);
@@ -49,6 +53,15 @@
   const apiUrl = config.apiUrl ?? '/api';
 
   const isDuelsImportBusy = $derived(importingDuelsReplays || importingDuelsBulk);
+
+  const filterSummary = $derived(`${total} total match${total === 1 ? '' : 'es'}`);
+  const filterBadges = $derived<string[]>(
+    [
+      filterPlayerName ? `Player: ${filterPlayerName}` : '',
+      filterStage ? `Stage: ${filterStage}` : '',
+      filterTime ? `Last ${filterTime}d` : '',
+    ].filter((b) => b.length > 0)
+  );
 
   let duelsImportMenu = $state<HTMLElement | null>(null);
 
@@ -411,10 +424,7 @@
     </div>
   {:else}
     <div class="row matches-header">
-      <h2 class="card__title" style="margin: 0;">
-        Matches
-        <span class="matches-header__count muted" aria-label="Total matches">({total})</span>
-      </h2>
+      <h2 class="card__title" style="margin: 0;">Matches</h2>
       <div class="row" style="gap: var(--space-sm); flex-wrap: wrap;">
         <a href="/matches/quick" class="btn">Quick match</a>
         <a href="/tournaments" class="btn">Tournaments</a>
@@ -465,7 +475,12 @@
       <p class="alert matches-page__duels-alert" role="alert">{duelsBulkImportError}</p>
     {/if}
 
-    <div class="filters card">
+    <FilterCard
+      bind:expanded={filtersExpanded}
+      summary={filterSummary}
+      badges={filterBadges}
+      panelId="matches-filters-panel"
+    >
       <div class="filters__row">
         <label class="filters__label" for="filter-player-btn">
           <span class="muted" style="font-size: 0.85rem;">Player</span>
@@ -509,12 +524,9 @@
         </label>
       </div>
       <div class="filters__footer">
-        <p class="filters__count muted">
-          {total} total match{total === 1 ? '' : 'es'}
-        </p>
         <button type="button" class="btn" onclick={clearFilters}>Clear filters</button>
       </div>
-    </div>
+    </FilterCard>
 
     <PlayerPickerModal
       bind:open={playerPickerOpen}

--- a/apps/web/src/routes/matches/+page.svelte
+++ b/apps/web/src/routes/matches/+page.svelte
@@ -165,6 +165,10 @@
     filterPlayerName = '';
   }
 
+  const canClearFilters = $derived(
+    !!(filterStage || filterTime || filterPlayerId || filterTournamentId),
+  );
+
   $effect(() => {
     const tid = $page.url.searchParams.get('tournamentId');
     const s = $page.url.searchParams.get('stage');
@@ -400,6 +404,8 @@
       summary={filterSummary}
       badges={filterBadges}
       panelId="matches-filters-panel"
+      onClear={clearFilters}
+      canClear={canClearFilters}
     >
       <div class="filters__row">
         <label class="filters__label" for="filter-player-btn">

--- a/apps/web/src/routes/players/+page.svelte
+++ b/apps/web/src/routes/players/+page.svelte
@@ -108,6 +108,14 @@
     currentPage = page;
   }
 
+  function clearPlayerFilters() {
+    filterTeam = '';
+    includeGuests = false;
+    currentPage = 1;
+  }
+
+  const canClearPlayerFilters = $derived(!!(filterTeam.trim() || includeGuests));
+
   $effect(() => {
     includeGuests;
     void (async () => {
@@ -165,6 +173,8 @@
       summary={filterSummary}
       badges={filterBadges}
       panelId="players-filters-panel"
+      onClear={clearPlayerFilters}
+      canClear={canClearPlayerFilters}
     >
       <div class="filters__row">
         <label class="filters__label" for="filter-team">

--- a/apps/web/src/routes/players/+page.svelte
+++ b/apps/web/src/routes/players/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { config } from '$lib/config';
   import { getAuthToken } from '$lib/auth';
-  import IconFilter from '$lib/icons/IconFilter.svelte';
+  import FilterCard from '$lib/FilterCard.svelte';
   import Pagination from '$lib/Pagination.svelte';
 
   let players = $state<Array<{ _id: string; name: string; team: string; isGuest?: boolean }>>([]);
@@ -17,12 +17,15 @@
   let includeGuests = $state(false);
   let appliedDefaultTeamFilter = $state(false);
 
-  /** Filter panel starts collapsed (same pattern as tournaments list). */
+  /** Filter panel starts collapsed (shared FilterCard pattern). */
   let filtersExpanded = $state(false);
 
   const apiUrl = config.apiUrl ?? '/api';
 
-  const hasGuestFilterOn = $derived(includeGuests);
+  const filterBadges = $derived<string[]>(includeGuests ? ['Guests'] : []);
+  const filterSummary = $derived(
+    `${total} player${total === 1 ? '' : 's'}${includeGuests ? '' : ' (guests hidden)'}`
+  );
 
   async function fetchPlayers() {
     loading = true;
@@ -30,7 +33,7 @@
     try {
       const params = new URLSearchParams();
       params.set('page', String(currentPage));
-      params.set('limit', '20');
+      params.set('limit', '15');
       const team = filterTeam.trim();
       if (team) {
         params.set('team', team);
@@ -157,72 +160,43 @@
       <a href="/players/new" class="btn btn--primary">New player</a>
     </div>
 
-    <div class="players-page__filters-wrap">
-      <div class="card stack players-page__filters">
-        <button
-          type="button"
-          class="players-page__filters-toggle"
-          aria-expanded={filtersExpanded}
-          aria-controls="players-filters-panel"
-          onclick={() => (filtersExpanded = !filtersExpanded)}
-        >
-          <span class="players-page__filters-toggle-main">
-            <span class="players-page__filters-toggle-icon" aria-hidden="true">
-              <IconFilter size={20} />
-            </span>
-            <span class="players-page__filters-toggle-label">Filters</span>
-            {#if hasGuestFilterOn}
-              <span class="players-page__filters-toggle-badge" aria-hidden="true">Guests</span>
-            {/if}
-          </span>
-          <span class="players-page__filters-chevron" aria-hidden="true"
-            >{filtersExpanded ? '▼' : '▶'}</span
+    <FilterCard
+      bind:expanded={filtersExpanded}
+      summary={filterSummary}
+      badges={filterBadges}
+      panelId="players-filters-panel"
+    >
+      <div class="filters__row">
+        <label class="filters__label" for="filter-team">
+          <span class="muted" style="font-size: 0.85rem;">Team</span>
+          <select
+            id="filter-team"
+            class="input filters__select"
+            bind:value={filterTeam}
+            onchange={() => (currentPage = 1)}
+            aria-label="Filter by team"
           >
-        </button>
-        {#if filtersExpanded}
-          <div id="players-filters-panel" class="players-page__filters-panel">
-            <div class="filters__row">
-              <label class="filters__label" for="filter-team">
-                <span class="muted" style="font-size: 0.85rem;">Team</span>
-                <select
-                  id="filter-team"
-                  class="input filters__select"
-                  bind:value={filterTeam}
-                  onchange={() => (currentPage = 1)}
-                  aria-label="Filter by team"
-                >
-                  <option value="">All teams</option>
-                  {#each teamNames as team}
-                    <option value={team}>{team}</option>
-                  {/each}
-                </select>
-              </label>
-              <label
-                class="filters__label filters__label--checkbox"
-                for="filter-include-guests"
-                style="display: flex; align-items: center; gap: 0.35rem;"
-              >
-                <input
-                  id="filter-include-guests"
-                  type="checkbox"
-                  bind:checked={includeGuests}
-                  onchange={() => (currentPage = 1)}
-                />
-                <span class="muted" style="font-size: 0.85rem;">Show guests</span>
-              </label>
-            </div>
-            <p class="filters__count muted" style="margin: 0;">
-              {total} player{total === 1 ? '' : 's'}{includeGuests ? '' : ' (guests hidden)'}
-            </p>
-          </div>
-        {/if}
+            <option value="">All teams</option>
+            {#each teamNames as team}
+              <option value={team}>{team}</option>
+            {/each}
+          </select>
+        </label>
+        <label
+          class="filters__label filters__label--checkbox"
+          for="filter-include-guests"
+          style="display: flex; align-items: center; gap: 0.35rem;"
+        >
+          <input
+            id="filter-include-guests"
+            type="checkbox"
+            bind:checked={includeGuests}
+            onchange={() => (currentPage = 1)}
+          />
+          <span class="muted" style="font-size: 0.85rem;">Show guests</span>
+        </label>
       </div>
-      {#if !filtersExpanded}
-        <p class="muted players-page__filters-summary">
-          {total} player{total === 1 ? '' : 's'}{includeGuests ? '' : ' (guests hidden)'}
-        </p>
-      {/if}
-    </div>
+    </FilterCard>
 
     {#if players.length === 0 && filterTeam.trim()}
       <div class="card stack">
@@ -269,82 +243,5 @@
 <style>
   .players-page {
     max-width: 720px;
-  }
-  .players-page__filters-wrap {
-    margin-top: var(--space-md, 1rem);
-    margin-bottom: var(--space-md, 1rem);
-  }
-  .players-page__filters {
-    gap: 0;
-  }
-  .players-page__filters-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    gap: 0.75rem;
-    padding: 0.65rem 0.35rem;
-    margin: 0;
-    border: none;
-    border-radius: var(--radius-sm, 6px);
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    font-weight: 600;
-    font-size: 1rem;
-    cursor: pointer;
-    text-align: left;
-    transition: background 0.15s ease;
-  }
-  .players-page__filters-toggle:hover {
-    background: var(--glass-bg-strong, rgba(255, 255, 255, 0.06));
-  }
-  .players-page__filters-toggle-main {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-width: 0;
-  }
-  .players-page__filters-toggle-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    color: var(--muted);
-  }
-  .players-page__filters-toggle:hover .players-page__filters-toggle-icon {
-    color: var(--fg);
-  }
-  .players-page__filters-toggle-label {
-    flex-shrink: 0;
-  }
-  .players-page__filters-toggle-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 0.15rem 0.45rem;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--color-accent, #3b82f6) 18%, transparent);
-    color: var(--fg);
-  }
-  .players-page__filters-chevron {
-    flex-shrink: 0;
-    font-size: 0.75rem;
-    color: var(--muted);
-    width: 1.25rem;
-    text-align: center;
-  }
-  .players-page__filters-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-    padding-top: 0.35rem;
-    border-top: 1px solid color-mix(in srgb, var(--color-fg, #111) 10%, transparent);
-    margin-top: 0.35rem;
-  }
-  .players-page__filters-summary {
-    margin: 0.35rem 0 0;
-    padding: 0 0.35rem;
-    font-size: 0.875rem;
-    line-height: 1.4;
   }
 </style>

--- a/apps/web/src/routes/tournaments/[id]/+page.svelte
+++ b/apps/web/src/routes/tournaments/[id]/+page.svelte
@@ -583,6 +583,8 @@
               summary={tournamentFilterSummary}
               badges={tournamentFilterBadges}
               panelId="tournament-detail-round-filters"
+              onClear={clearTournamentViewFilters}
+              canClear={canClearTournamentFilters}
             >
               <div class="stack" style="gap: 0.5rem;">
                 <span class="tournament-detail__filters-label muted">Round</span>
@@ -642,6 +644,8 @@
               summary={tournamentFilterSummary}
               badges={tournamentFilterBadges}
               panelId="tournament-detail-player-filters"
+              onClear={clearTournamentViewFilters}
+              canClear={canClearTournamentFilters}
             >
               <label class="label tournament-detail__filters-label" for="tournament-player-filter"
                 >Player 1</label

--- a/apps/web/src/routes/tournaments/[id]/+page.svelte
+++ b/apps/web/src/routes/tournaments/[id]/+page.svelte
@@ -9,6 +9,7 @@
     getMatchRoundKey,
     matchStageOrTournamentLabel,
   } from '$lib/lorcana-match';
+  import FilterCard from '$lib/FilterCard.svelte';
   import InkIcons from '$lib/InkIcons.svelte';
   import IconCrown from '$lib/icons/IconCrown.svelte';
 
@@ -60,6 +61,9 @@
   let roundFilter = $state<RoundFilter>('all');
   let playerFilterId = $state('');
 
+  /** Collapsible filter card (shared pattern with /matches, /decks). */
+  let filtersExpanded = $state(false);
+
   function compareRoundKeys(a: string, b: string): number {
     const na = Number(a);
     const nb = Number(b);
@@ -104,6 +108,31 @@
     const pid = playerFilterId.trim();
     return matches.filter((m) => getLorcanaMatchPlayerId(m.p1) === pid);
   });
+
+  const tournamentFilterSummary = $derived(
+    `${displayedMatches.length} of ${matches.length} shown`,
+  );
+
+  const tournamentFilterBadges = $derived.by(() => {
+    const badges: string[] = [];
+    if (activeView === 'rounds') {
+      if (roundFilter === 'none') badges.push('Round: No round');
+      else if (roundFilter !== 'all') badges.push(`Round: ${formatMatchRoundLabel(roundFilter)}`);
+    } else if (playerFilterId.trim()) {
+      const pair = tournamentPlayers.find(([id]) => id === playerFilterId.trim());
+      if (pair) badges.push(`P1: ${pair[1]}`);
+    }
+    return badges;
+  });
+
+  const canClearTournamentFilters = $derived(
+    activeView === 'rounds' ? roundFilter !== 'all' : !!playerFilterId.trim(),
+  );
+
+  function clearTournamentViewFilters(): void {
+    if (activeView === 'rounds') roundFilter = 'all';
+    else playerFilterId = '';
+  }
 
   function playerName(p: Player | LorcanaMatchPlayer | string | undefined): string {
     if (!p) return '–';
@@ -545,61 +574,101 @@
       {#if activeView === 'rounds'}
         <div
           id="panel-tournament-rounds"
-          class="card stack tournament-detail__filters"
           role="tabpanel"
           aria-labelledby="tab-tournament-rounds"
         >
-          <span class="tournament-detail__filters-label muted">Round</span>
-          <div class="tournament-detail__chips" aria-label="Filter by round">
-            <button
-              type="button"
-              class="tournament-detail__chip"
-              class:tournament-detail__chip--active={roundFilter === 'all'}
-              onclick={() => (roundFilter = 'all')}
+          <div class="tournament-detail__filters">
+            <FilterCard
+              bind:expanded={filtersExpanded}
+              summary={tournamentFilterSummary}
+              badges={tournamentFilterBadges}
+              panelId="tournament-detail-round-filters"
             >
-              All
-            </button>
-            {#if hasUnassignedRound}
-              <button
-                type="button"
-                class="tournament-detail__chip"
-                class:tournament-detail__chip--active={roundFilter === 'none'}
-                onclick={() => (roundFilter = 'none')}
-              >
-                No round
-              </button>
-            {/if}
-            {#each roundNumbers as r (r)}
-              <button
-                type="button"
-                class="tournament-detail__chip"
-                class:tournament-detail__chip--active={roundFilter === r}
-                onclick={() => (roundFilter = r)}
-              >
-                {formatMatchRoundLabel(r)}
-              </button>
-            {/each}
+              <div class="stack" style="gap: 0.5rem;">
+                <span class="tournament-detail__filters-label muted">Round</span>
+                <div class="tournament-detail__chips" aria-label="Filter by round">
+                  <button
+                    type="button"
+                    class="tournament-detail__chip"
+                    class:tournament-detail__chip--active={roundFilter === 'all'}
+                    onclick={() => (roundFilter = 'all')}
+                  >
+                    All
+                  </button>
+                  {#if hasUnassignedRound}
+                    <button
+                      type="button"
+                      class="tournament-detail__chip"
+                      class:tournament-detail__chip--active={roundFilter === 'none'}
+                      onclick={() => (roundFilter = 'none')}
+                    >
+                      No round
+                    </button>
+                  {/if}
+                  {#each roundNumbers as r (r)}
+                    <button
+                      type="button"
+                      class="tournament-detail__chip"
+                      class:tournament-detail__chip--active={roundFilter === r}
+                      onclick={() => (roundFilter = r)}
+                    >
+                      {formatMatchRoundLabel(r)}
+                    </button>
+                  {/each}
+                </div>
+              </div>
+              <div class="filters__footer">
+                <button
+                  type="button"
+                  class="btn"
+                  onclick={clearTournamentViewFilters}
+                  disabled={!canClearTournamentFilters}
+                >
+                  Clear filters
+                </button>
+              </div>
+            </FilterCard>
           </div>
         </div>
       {:else}
         <div
           id="panel-tournament-players"
-          class="card stack tournament-detail__filters"
           role="tabpanel"
           aria-labelledby="tab-tournament-players"
         >
-          <label class="label tournament-detail__filters-label" for="tournament-player-filter">Player 1</label>
-          <select
-            id="tournament-player-filter"
-            class="input"
-            bind:value={playerFilterId}
-            aria-label="Filter matches by player 1 (left seat)"
-          >
-            <option value="">All matches</option>
-            {#each tournamentPlayers as [pid, label] (pid)}
-              <option value={pid}>{label}</option>
-            {/each}
-          </select>
+          <div class="tournament-detail__filters">
+            <FilterCard
+              bind:expanded={filtersExpanded}
+              summary={tournamentFilterSummary}
+              badges={tournamentFilterBadges}
+              panelId="tournament-detail-player-filters"
+            >
+              <label class="label tournament-detail__filters-label" for="tournament-player-filter"
+                >Player 1</label
+              >
+              <select
+                id="tournament-player-filter"
+                class="input"
+                bind:value={playerFilterId}
+                aria-label="Filter matches by player 1 (left seat)"
+              >
+                <option value="">All matches</option>
+                {#each tournamentPlayers as [pid, label] (pid)}
+                  <option value={pid}>{label}</option>
+                {/each}
+              </select>
+              <div class="filters__footer">
+                <button
+                  type="button"
+                  class="btn"
+                  onclick={clearTournamentViewFilters}
+                  disabled={!canClearTournamentFilters}
+                >
+                  Clear filters
+                </button>
+              </div>
+            </FilterCard>
+          </div>
         </div>
       {/if}
 
@@ -610,9 +679,6 @@
           </p>
         </div>
       {:else}
-        <p class="muted tournament-detail__filter-meta">
-          Showing {displayedMatches.length} of {matches.length} loaded
-        </p>
         <div class="stack">
           {#each displayedMatches as match (match._id)}
             {@const p1Id = typeof match.p1 === 'object' && match.p1 ? match.p1._id : match.p1}
@@ -804,10 +870,6 @@
   .tournament-detail__chip--active {
     border-color: var(--color-accent, #3b82f6);
     background: color-mix(in srgb, var(--color-accent, #3b82f6) 12%, transparent);
-  }
-  .tournament-detail__filter-meta {
-    margin: 0 0 var(--space-sm, 0.5rem) 0;
-    font-size: 0.8125rem;
   }
 
   .tournament-detail__delete-modal {


### PR DESCRIPTION
Closes #11

## Summary
Standardise the filter UI and pagination across the three primary list pages (`/matches`, `/players`, `/decks`).

- Extract `apps/web/src/lib/FilterCard.svelte` from the existing `/players` collapsible card pattern. API: `title`, `expanded` (bindable), `summary`, `badges[]`, and a children snippet for the actual filter inputs.
- Move shared styles into `apps/web/src/app.css` under a `.filter-card*` namespace so future lists can reuse them.
- Migrate all three list pages to the shared component:
  - `/players`: replaces inline collapsible card; page-local `.players-page__filters*` CSS removed.
  - `/matches`: replaces always-open `.filters card` block; surfaces active player/stage/time as badges. Removes the duplicate match count from the page header.
  - `/decks`: replaces bare `<select>`s with the same collapsible card; surfaces active color/player as badges.
- Standardise page size to **15** across all three lists (was 10/20/5).

## Test plan
- [x] `npm run lint` — no new errors in touched files.
- [x] `npm run build:web` — Svelte/Vite compilation passes.
- [ ] Each list page (`/matches`, `/players`, `/decks`) loads, filters expand/collapse, badges show active filters, summary count is correct, pagination works.