### PR TITLE
feat(date): user-locale formatters and relative time in lists

### DIFF
--- a/apps/web/src/lib/DateDisplay.ts
+++ b/apps/web/src/lib/DateDisplay.ts
@@ -1,5 +1,31 @@
-/** Locale-aware date strings for lists, stats, and match metadata. */
+/**
+ * Locale-aware date strings for lists, stats, and match metadata.
+ *
+ * All formatters use the user's locale (`undefined` argument to the `Intl`
+ * APIs lets the browser pick `navigator.language`). Lists should prefer
+ * `formatRelative`; detail pages and metadata rows should use `formatDateTime`
+ * or `formatDate`.
+ */
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
 export class DateDisplay {
+  /** Short date + time using the user's locale (e.g. `4/29/26, 11:05 AM`). */
+  static formatDateTime(s: string | undefined): string {
+    if (!s) return '–';
+    try {
+      return new Date(s).toLocaleString(undefined, {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      });
+    } catch {
+      return s;
+    }
+  }
+
+  /** Medium date only, e.g. `Apr 29, 2026` (en-US). */
   static formatDate(s: string | undefined): string {
     if (!s) return '–';
     try {
@@ -9,20 +35,71 @@ export class DateDisplay {
     }
   }
 
-  static formatRelativeDate(s: string | undefined): string {
+  /**
+   * Relative time tuned for list rows.
+   *
+   * - `< 60s`             → `just now`
+   * - `< 60m`             → `5m ago`
+   * - `< 24h`             → `2h ago`
+   * - same calendar day   → `2h ago` (covered above)
+   * - previous calendar day → `Yesterday`
+   * - 2–6 days ago        → `3d ago` via `Intl.RelativeTimeFormat`
+   * - older, current year → `Mar 4`
+   * - older, other year   → `Mar 4 2024`
+   *
+   * Future timestamps are formatted symmetrically (`in 5m`, `Tomorrow`, …).
+   */
+  static formatRelative(s: string | undefined): string {
     if (!s) return '–';
     try {
       const d = new Date(s);
-      const now = new Date();
-      const diffMs = now.getTime() - d.getTime();
-      const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
-      if (diffDays === 0) return 'Today';
-      if (diffDays === 1) return 'Yesterday';
-      if (diffDays < 7) return `${diffDays} days ago`;
-      if (diffDays < 14) return 'Last week';
-      return DateDisplay.formatDate(s);
+      const t = d.getTime();
+      if (Number.isNaN(t)) return s;
+      const now = Date.now();
+      const diffMs = t - now;
+      const absMs = Math.abs(diffMs);
+
+      if (absMs < MINUTE_MS) return 'just now';
+
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+      if (absMs < HOUR_MS) {
+        const minutes = Math.round(diffMs / MINUTE_MS);
+        return rtf.format(minutes, 'minute');
+      }
+
+      if (absMs < DAY_MS) {
+        const hours = Math.round(diffMs / HOUR_MS);
+        return rtf.format(hours, 'hour');
+      }
+
+      // Use calendar-day diff so "yesterday" lines up with the user's clock,
+      // not a fixed 24 h window.
+      const startOfToday = new Date();
+      startOfToday.setHours(0, 0, 0, 0);
+      const startOfThat = new Date(d);
+      startOfThat.setHours(0, 0, 0, 0);
+      const dayDiff = Math.round(
+        (startOfThat.getTime() - startOfToday.getTime()) / DAY_MS
+      );
+
+      if (Math.abs(dayDiff) < 7) {
+        return rtf.format(dayDiff, 'day');
+      }
+
+      const sameYear = d.getFullYear() === new Date().getFullYear();
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: sameYear ? undefined : 'numeric',
+      }).format(d);
     } catch {
-      return s ?? '–';
+      return s;
     }
+  }
+
+  /** @deprecated Use {@link DateDisplay.formatRelative}. Kept as alias for older callers. */
+  static formatRelativeDate(s: string | undefined): string {
+    return DateDisplay.formatRelative(s);
   }
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -11,6 +11,7 @@
   } from '$lib/lorcana-match';
   import InkIcons from '$lib/InkIcons.svelte';
   import IconCrown from '$lib/icons/IconCrown.svelte';
+  import { DateDisplay } from '$lib/DateDisplay';
 
   type Player = { _id: string; name: string; team?: string };
 
@@ -78,24 +79,6 @@
   function playerName(p: Player | LorcanaMatchPlayer | string | undefined): string {
     if (!p) return '–';
     return typeof p === 'string' ? p : p.name ?? '–';
-  }
-
-  function formatDate(s: string | undefined): string {
-    if (!s) return '–';
-    try {
-      return new Date(s).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
-    } catch {
-      return s;
-    }
-  }
-
-  function formatTournamentDay(iso: string | undefined): string {
-    if (!iso) return '–';
-    try {
-      return new Date(iso).toLocaleDateString('de-DE', { dateStyle: 'medium' });
-    } catch {
-      return iso;
-    }
   }
 
   function localCalendarDay(): string {
@@ -287,7 +270,7 @@
                     <a href="/tournaments/{t._id}" class="dashboard__tournaments-link">
                       <span class="dashboard__tournaments-name">{t.name}</span>
                       <span class="muted dashboard__tournaments-date">
-                        {formatTournamentDay(t.date)}{#if t.meta?.trim()} · {t.meta.trim()}{/if}
+                        {DateDisplay.formatDate(t.date)}{#if t.meta?.trim()} · {t.meta.trim()}{/if}
                       </span>
                     </a>
                   </li>
@@ -306,7 +289,7 @@
                     <a href="/tournaments/{t._id}" class="dashboard__tournaments-link">
                       <span class="dashboard__tournaments-name">{t.name}</span>
                       <span class="muted dashboard__tournaments-date">
-                        {formatTournamentDay(t.date)}{#if t.meta?.trim()} · {t.meta.trim()}{/if}
+                        {DateDisplay.formatDate(t.date)}{#if t.meta?.trim()} · {t.meta.trim()}{/if}
                       </span>
                     </a>
                   </li>
@@ -360,7 +343,7 @@
                 style="text-decoration: none; color: inherit;"
               >
                 <div class="matchcard__top muted">
-                  {formatDate(match.playedAt)} · {matchStageOrTournamentLabel(match)}{#if getMatchRoundKey(match.round) != null}
+                  {DateDisplay.formatRelative(match.playedAt)} · {matchStageOrTournamentLabel(match)}{#if getMatchRoundKey(match.round) != null}
                     · {formatMatchRoundLabel(match.round)}{/if}
                 </div>
                 <div class="matchcard__row">

--- a/apps/web/src/routes/matches/+page.svelte
+++ b/apps/web/src/routes/matches/+page.svelte
@@ -16,6 +16,7 @@
   import IconUpload from '$lib/icons/IconUpload.svelte';
   import Pagination from '$lib/Pagination.svelte';
   import PlayerPickerModal from '$lib/PlayerPickerModal.svelte';
+  import { DateDisplay } from '$lib/DateDisplay';
 
   type Player = { _id: string; name: string; team?: string };
 
@@ -79,15 +80,6 @@
   function playerName(p: Player | LorcanaMatchPlayer | string | undefined): string {
     if (!p) return '–';
     return typeof p === 'string' ? p : (p.name ?? '–');
-  }
-
-  function formatDate(s: string | undefined): string {
-    if (!s) return '–';
-    try {
-      return new Date(s).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
-    } catch {
-      return s;
-    }
   }
 
   function matchWinnerId(m: LorcanaMatch): string | undefined {
@@ -540,7 +532,7 @@
             style="text-decoration: none; color: inherit;"
           >
             <div class="matchcard__top muted">
-              {formatDate(match.playedAt)} · {matchStageOrTournamentLabel(match)}{#if getMatchRoundKey(match.round) != null}
+              {DateDisplay.formatRelative(match.playedAt)} · {matchStageOrTournamentLabel(match)}{#if getMatchRoundKey(match.round) != null}
                 · {formatMatchRoundLabel(match.round)}{/if}
             </div>
             <div class="matchcard__row">

--- a/apps/web/src/routes/matches/[id]/+page.svelte
+++ b/apps/web/src/routes/matches/[id]/+page.svelte
@@ -131,7 +131,7 @@
   function formatDate(s: string | undefined): string {
     if (!s) return '–';
     try {
-      return new Date(s).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+      return new Date(s).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
     } catch {
       return s;
     }

--- a/apps/web/src/routes/tournaments/+page.svelte
+++ b/apps/web/src/routes/tournaments/+page.svelte
@@ -57,7 +57,7 @@
   function formatDate(iso: string | null | undefined): string {
     if (!iso) return '–';
     try {
-      return new Date(iso).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+      return new Date(iso).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
     } catch {
       return String(iso);
     }

--- a/apps/web/src/routes/tournaments/[id]/+page.svelte
+++ b/apps/web/src/routes/tournaments/[id]/+page.svelte
@@ -113,7 +113,7 @@
   function formatDate(s: string | undefined): string {
     if (!s) return '–';
     try {
-      return new Date(s).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+      return new Date(s).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
     } catch {
       return s;
     }

--- a/apps/web/src/routes/tournaments/results/+page.svelte
+++ b/apps/web/src/routes/tournaments/results/+page.svelte
@@ -140,7 +140,7 @@
     try {
       const d = new Date(iso);
       if (Number.isNaN(d.getTime())) return iso;
-      return d.toLocaleString('de-DE', { dateStyle: 'medium', timeStyle: 'short' });
+      return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
     } catch {
       return iso;
     }


### PR DESCRIPTION
Closes #8

## Summary

`apps/web/src/lib/DateDisplay.ts` and the routes that display match/tournament dates were hardcoded to `toLocaleString('de-DE', …)`. Non-DE users saw `DD.MM.YY, HH:mm` regardless of their locale, and absolute timestamps in lists are slow to scan.

This PR centralises locale-aware formatting in `DateDisplay` and switches lists to relative time:

- **`lib/DateDisplay.ts`**: extends the helper with three locale-aware methods.
  - `formatDateTime(s)` — `dateStyle: 'short', timeStyle: 'short'`, user locale.
  - `formatDate(s)` — `dateStyle: 'medium'`, user locale.
  - `formatRelative(s)` — `just now` / `5m ago` / `2h ago` / `Yesterday` / `Mar 4` / `Mar 4 2024`, using `Intl.RelativeTimeFormat` for the last 7 days and `Intl.DateTimeFormat` for older entries (year only included when not the current year). Future timestamps render symmetrically (`in 5m`, `Tomorrow`, …).
  - `formatRelativeDate` is kept as a deprecated alias of `formatRelative` so the existing `MatchLineRow` caller picks up the new behaviour.
- **Lists use relative time**:
  - `routes/+page.svelte` (dashboard "Recent matches") — `match.playedAt` now uses `DateDisplay.formatRelative`.
  - `routes/matches/+page.svelte` — match rows now use `DateDisplay.formatRelative`.
- **De-duped helpers**: removed the inline `formatDate` / `formatTournamentDay` from `routes/+page.svelte` and the inline `formatDate` from `routes/matches/+page.svelte`, importing from `\$lib/DateDisplay` instead.
- **Locale audit**: every remaining `'de-DE'` argument in `apps/web/src` (`routes/matches/[id]/+page.svelte`, `routes/tournaments/+page.svelte`, `routes/tournaments/[id]/+page.svelte`, `routes/tournaments/results/+page.svelte`) is replaced with `undefined` so each user sees dates in their own locale.
- `rg "de-DE" apps/web/src` returns no matches after the change.

## Test plan

- [ ] Visit `/` and `/matches` in `en-US` and `de-DE` locales — list rows should show relative labels like `2h ago` / `Yesterday` / `Mar 4`, and the dashboard tournament rows should show medium absolute dates in the active locale.
- [ ] Visit `/matches/{id}` and `/tournaments/{id}` — absolute timestamps should now follow the active browser locale instead of always being German.
- [ ] Verify `formatRelative` corner cases: just-now (< 60 s), minutes / hours, calendar yesterday, 3 days ago, last week, older same-year (`Mar 4`), and older other-year (`Mar 4 2024`).

## Notes

- The "build:web" command in this sandbox exits before vite's writeBundle hook completes, but this also reproduces on `main` without these changes, so it is a pre-existing environmental issue (the actual Vite/Rollup compile of the changed files succeeds).
- No new lint warnings introduced; remaining warnings/errors in the touched files all pre-exist on `main`.

Made with [Cursor](https://cursor.com)